### PR TITLE
Refac: update post to use a store instead of custom events

### DIFF
--- a/src/components/customComponent.js
+++ b/src/components/customComponent.js
@@ -37,6 +37,8 @@ export class CustomComponent extends HTMLElement {
       const slot = this.getSlot(slotName);
 
       switch (this.determineValueType(value)) {
+        case "null":
+          break;
         case "primitive":
           this.populateSlotWithText(slot, value);
           break;
@@ -56,6 +58,10 @@ export class CustomComponent extends HTMLElement {
   }
 
   determineValueType(value) {
+    if (value === null) {
+      return "null";
+    }
+
     if (typeof value === "string" || typeof value === "number") {
       return "primitive";
     }

--- a/src/components/post/post.js
+++ b/src/components/post/post.js
@@ -6,6 +6,7 @@ import { PostHeader } from "./postHeader.js";
 import { PostInputComment } from "./postInputComment.js";
 import { Store } from "../../lib/stores/store.js";
 import "../../lib/services/posts.js"; // to get vscode to pick up the jsdoc types
+import { PostMedia } from "./postMedia.js";
 
 export class Post extends CustomComponent {
   /**
@@ -26,46 +27,13 @@ export class Post extends CustomComponent {
     this.innerHTML = postHtml;
 
     this.populateData({
-      postHeader: this.setPostHeader(),
-      postBody: this.setPostBody(),
-      postMedia: this.setPostMedia(),
-      postButtons: this.setPostButtons(),
-      postCommentList: this.setPostCommentList(),
-      inputComment: this.setPostInputComment(),
+      postHeader: new PostHeader(this.postData.author, this.postData.created),
+      postBody: this.postData.body || "",
+      postMedia: new PostMedia(this.postData),
+      postButtons: new PostButtons(this.store),
+      postCommentList: new PostCommentList(this.postData, this.store),
+      inputComment: new PostInputComment(this.postData, this.store),
     });
-  }
-
-  setPostHeader() {
-    return new PostHeader(this.postData.author, this.postData.created);
-  }
-
-  setPostBody() {
-    return this.postData.body || ""; // TODO: Add support for images
-  }
-
-  setPostMedia() {
-    if (this.postData.media) {
-      const image = document.createElement("img");
-      image.src = this.postData.media;
-      image.alt = `${this.postData.author.name} posted an image with the title ${this.postData.title}.`;
-      image.classList.add("post-media");
-      return image;
-    }
-  }
-
-  setPostButtons() {
-    return new PostButtons(this.postData, this.store);
-  }
-
-  setPostCommentList() {
-    const postCommentList = new PostCommentList(this.postData, this.store);
-
-    return postCommentList.getCommentElements();
-  }
-
-  setPostInputComment() {
-    const postInputComment = new PostInputComment(this.postData, this.store);
-    return postInputComment.getInputCommentField();
   }
 }
 

--- a/src/components/post/post.js
+++ b/src/components/post/post.js
@@ -4,6 +4,8 @@ import { PostButtons } from "./postButtons.js";
 import { PostCommentList } from "./postCommentList";
 import { PostHeader } from "./postHeader.js";
 import { PostInputComment } from "./postInputComment.js";
+import { Store } from "../../lib/stores/store.js";
+import "../../lib/services/posts.js"; // to get vscode to pick up the jsdoc types
 
 export class Post extends CustomComponent {
   /**
@@ -12,6 +14,12 @@ export class Post extends CustomComponent {
   constructor(postData) {
     super();
     this.postData = postData;
+    this.store = new Store({
+      commentsOpen: false,
+      commentInputOpen: false,
+      comments: [...this.postData.comments],
+      reactions: [...this.postData.reactions],
+    });
   }
 
   connectedCallback() {
@@ -46,17 +54,17 @@ export class Post extends CustomComponent {
   }
 
   setPostButtons() {
-    return new PostButtons(this.postData);
+    return new PostButtons(this.postData, this.store);
   }
 
   setPostCommentList() {
-    const postCommentList = new PostCommentList(this.postData);
+    const postCommentList = new PostCommentList(this.postData, this.store);
 
     return postCommentList.getCommentElements();
   }
 
   setPostInputComment() {
-    const postInputComment = new PostInputComment(this.postData);
+    const postInputComment = new PostInputComment(this.postData, this.store);
     return postInputComment.getInputCommentField();
   }
 }

--- a/src/components/post/postButtons.js
+++ b/src/components/post/postButtons.js
@@ -8,12 +8,14 @@ import postButtons from "./postButtons.html?raw";
 export class PostButtons extends CustomComponent {
   /**
    * @param {PostDataComplete} postData - The full post data returned from the API, expects the _comments, _reactions and _author flags to be set to true.
+   * @param {Store} store - The store to use for the component.
    */
-  constructor(postData) {
+  constructor(postData, store) {
     super();
     this.postData = postData;
     this.commentsCount = this.postData.comments.length;
     this.reactionsCount = this.postData.reactions.length;
+    this.store = store;
   }
 
   connectedCallback() {
@@ -22,6 +24,7 @@ export class PostButtons extends CustomComponent {
       viewCommentsBtn: this.commentsCount,
       viewReactionsBtn: this.reactionsCount,
     });
+
     this.addEventListeners();
     this.handleOptimisticCommentUpdate();
   }
@@ -33,35 +36,28 @@ export class PostButtons extends CustomComponent {
 
   handleViewCommentsBtnClick = () => {
     this.onClick("viewCommentsBtn", (event) => {
-      const state = this.toggleState(event);
-      this.dispatchToggleCommentsEvent(state);
+      this.store.setState((currentState) => ({
+        ...currentState,
+        commentsOpen: !currentState.commentsOpen,
+        commentInputOpen: currentState.commentsOpen,
+      }));
+      const isCommentsOpen = this.store.getState((state) => state.commentsOpen);
+      this.toggleViewCommentsBtnState(event.currentTarget, isCommentsOpen);
     });
   };
 
-  toggleState(event) {
-    const {
-      currentTarget: { dataset },
-    } = event;
-    dataset.state = dataset.state === "open" ? "closed" : "open";
-    return dataset.state;
+  toggleViewCommentsBtnState(target, isCommentsOpen) {
+    isCommentsOpen
+      ? (target.dataset.state = "open")
+      : (target.dataset.state = "closed");
   }
 
-  dispatchToggleCommentsEvent = (state) => {
-    this.dispatchCustomEvent({
-      eventName: "toggleComments",
-      id: this.postData.id,
-      detail: { state },
-    });
-  };
-
   handleAddCommentBtnClick = () => {
-    this.onClick("addCommentBtn", () => this.dispatchAddCommentEvent());
-  };
-
-  dispatchAddCommentEvent = () => {
-    this.dispatchCustomEvent({
-      eventName: "addComment",
-      id: this.postData.id,
+    this.onClick("addCommentBtn", () => {
+      this.store.setState((currentState) => ({
+        ...currentState,
+        commentInputOpen: !currentState.commentInputOpen,
+      }));
     });
   };
 

--- a/src/components/post/postCommentList.js
+++ b/src/components/post/postCommentList.js
@@ -5,33 +5,23 @@ import tempPostCommentHtml from "./postCommentTemp.html?raw";
 export class PostCommentList extends CustomComponent {
   /**
    * @param {PostDataComplete} postData - The full post data returned from the API, expects the _comments, _reactions and _author flags to be set to true.
+   * @param {Store} store - The store to use for the component.
    */
-  constructor(postData) {
+  constructor(postData, store) {
     super();
     this.postData = postData;
+    this.store = store;
   }
 
   connectedCallback() {
     this.applyInitialStyles();
-    this.fillCommentList(this.postData.comments);
-    this.handleOptimisticCommentUpdate();
+    this.unsubscribeComments = this.store.subscribe((state) => {
+      this.fillCommentList(state.comments);
+    }, "comments");
 
-    this.onCustomEvent({
-      eventName: "toggleComments",
-      id: this.postData.id,
-      useDocument: true,
-      callback: (event) => this.toggleComments(event.detail.state),
-    });
-  }
-
-  applyInitialStyles() {
-    this.classList.add("peer", "flex", "hidden", "flex-col", "gap-5", "pt-4");
-  }
-
-  toggleComments(state) {
-    state === "open"
-      ? this.classList.remove("hidden")
-      : this.classList.add("hidden");
+    this.unsubscribeCommentsOpen = this.store.subscribe((state) => {
+      this.toggleComments(state.commentsOpen);
+    }, "commentsOpen");
   }
 
   fillCommentList(comments) {
@@ -41,6 +31,27 @@ export class PostCommentList extends CustomComponent {
       this.clearComments();
       this.renderComments(comments);
     }
+  }
+
+  disconnectedCallback() {
+    if (this.unsubscribeComments) {
+      this.unsubscribeComments();
+    }
+
+    if (this.unsubscribeCommentsOpen) {
+      this.unsubscribeCommentsOpen();
+    }
+  }
+
+  applyInitialStyles() {
+    this.classList.add("peer", "flex", "hidden", "flex-col", "gap-5", "pt-4");
+  }
+
+  toggleComments(commentsOpen) {
+    console.log("toggleComments", commentsOpen);
+    commentsOpen
+      ? this.classList.remove("hidden")
+      : this.classList.add("hidden");
   }
 
   showTemporaryComment() {

--- a/src/components/post/postInputComment.html
+++ b/src/components/post/postInputComment.html
@@ -6,7 +6,7 @@
 >
   <div class="relative">
     <textarea
-      class="block w-full rounded-md border border-stone-700 bg-black p-2 text-xl leading-none outline-none ring-2 ring-transparent transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-primary-800"
+      class="block w-full overflow-hidden rounded-md border border-stone-700 bg-black p-2 text-xl leading-none outline-none ring-2 ring-transparent transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-primary-800"
       type="text"
       name=""
       id="commentField"

--- a/src/components/post/postInputComment.js
+++ b/src/components/post/postInputComment.js
@@ -3,128 +3,125 @@ import { CustomComponent } from "../customComponent.js";
 
 export class PostInputComment extends CustomComponent {
   /**
-   * @param {PostDataComplete} postData - The full post data returned from the API, expects the _comments, _reactions and _author flags to be set to true.
+   * @param {PostDataComplete} postData - The full post data returned from the API.
    * @param {Store} store - The store to use for the component.
    */
   constructor(postData, store) {
     super();
     this.postData = postData;
     this.store = store;
+    this.inputOpenUnsubscribe = null;
+    this.commentsOpenUnsubscribe = null;
   }
 
   connectedCallback() {
+    this.initComponent();
+    this.subscribeToStore();
+    this.addEventListeners();
+  }
+
+  disconnectedCallback() {
+    this.unsubscribeFromStore();
+  }
+
+  initComponent() {
     this.classList.add("hidden");
     this.innerHTML = PostInputCommentHtml;
-    this.addEventListeners();
+  }
 
+  subscribeToStore() {
     this.inputOpenUnsubscribe = this.store.subscribe(
-      (state) => this.setCommentInputOpen(state),
+      (state) => this.toggleInputField(state),
       "commentInputOpen",
     );
-
     this.commentsOpenUnsubscribe = this.store.subscribe(
-      (state) => this.toggleComments(state.commentsOpen),
+      (state) => this.toggleComments(state),
       "commentsOpen",
     );
   }
 
-  disconnectedCallback() {
-    this.inputOpenUnsubscribe();
+  unsubscribeFromStore() {
+    if (this.inputOpenUnsubscribe) this.inputOpenUnsubscribe();
+    if (this.commentsOpenUnsubscribe) this.commentsOpenUnsubscribe();
   }
 
-  setCommentInputOpen(isOpen) {
-    console.log(isOpen);
-    isOpen ? this.handleOpen() : this.classList.add("hidden");
+  toggleInputField(isOpen) {
+    isOpen ? this.openInputField() : this.classList.add("hidden");
   }
 
-  handleOpen() {
+  openInputField() {
     this.classList.remove("hidden");
     this.getSlot("commentField").focus();
   }
 
+  toggleComments(commentsOpen) {
+    this.classList.toggle("hidden", !commentsOpen);
+  }
+
   addEventListeners() {
-    this.addEventListener("submit", this.handleSubmitComment);
+    this.addSubmitListener();
+    this.addEnterKeyListener();
+    this.addReplyToCommentListener();
+    this.addExpandTextFieldListener();
+  }
+
+  addSubmitListener() {
+    this.addEventListener("submit", this.handleSubmit);
+  }
+
+  addEnterKeyListener() {
     this.addEventListener("keydown", (event) => {
       if (event.key === "Enter" && !event.shiftKey) {
-        this.handleSubmitComment(event);
+        this.handleSubmit(event);
       }
     });
+  }
 
+  addReplyToCommentListener() {
     this.onCustomEvent({
       eventName: "replyToComment",
       id: this.postData.id,
       useDocument: true,
       callback: (event) => this.handleReplyToComment(event),
     });
-
-    this.handleExpandTextField();
   }
 
-  getInputCommentField() {
-    return this;
-  }
-
-  toggleComments = (commentsOpen) => {
-    commentsOpen
-      ? this.classList.remove("hidden")
-      : this.classList.add("hidden");
-  };
-
-  handleExpandTextField = () => {
+  addExpandTextFieldListener() {
     const textarea = this.getSlot("commentField");
     textarea.style.height = `${textarea.height}px`;
-
     textarea.addEventListener("input", function () {
       this.style.height = "auto";
       this.style.height = `${this.scrollHeight}px`;
     });
-  };
+  }
 
-  handleReplyToComment = (event) => {
-    this.classList.remove("hidden");
-    this.getSlot("commentField").focus();
-    this.getSlot("commentField").value = `@${event.detail.author.name} `;
-  };
-
-  handleTagUser = () => {
-    // TODO: Add functionality to tag users, this is just a placeholder
-
-    this.inputCommentField.addEventListener("keyup", (event) => {
-      const commentValue = event.target.innerText.trim();
-
-      const usernameRegex = /@(\w+)/g;
-      let match;
-
-      while ((match = usernameRegex.exec(commentValue)) !== null) {
-        console.log(match[1]);
-      }
-    });
-  };
-
-  handleSubmitComment = (event) => {
+  handleSubmit(event) {
     event.preventDefault();
-
     const commentField = this.getSlot("commentField");
-    commentField.style.height = "auto";
-
-    const commentValue = commentField.value.trim();
-
-    if (commentValue) {
-      const newComment = {
-        author: this.postData.author, // TODO: Replace with active user!
-        body: commentValue,
-        created: Date.now(),
-      };
-
+    const comment = commentField.value.trim();
+    if (comment) {
+      this.addNewComment(comment);
       commentField.value = "";
-
-      this.dispatchCustomEvent({
-        eventName: "addCommentOptimistically",
-        id: this.postData.id,
-        detail: newComment,
-      });
     }
-  };
+  }
+
+  handleReplyToComment(event) {
+    this.openInputField();
+    const commentField = this.getSlot("commentField");
+    commentField.value = `@${event.detail.author.name} `;
+  }
+
+  addNewComment(comment) {
+    const newComment = {
+      author: this.postData.author, //TODO: Replace with active user info when available
+      body: comment,
+      created: Date.now(),
+    };
+
+    this.store.setState((currentState) => ({
+      comments: [...currentState.comments, newComment],
+    }));
+  }
 }
 
 customElements.define("post-input-comment", PostInputComment);

--- a/src/components/post/postMedia.js
+++ b/src/components/post/postMedia.js
@@ -1,0 +1,32 @@
+import { CustomComponent } from "../customComponent.js";
+
+export class PostMedia extends CustomComponent {
+  /**
+   * @param {PostDataComplete} postData - The full post data returned from the API, expects the _comments, _reactions and _author flags to be set to true.
+   */
+  constructor(postData) {
+    super();
+    this.postData = postData;
+  }
+
+  connectedCallback() {
+    const mediaElement = this.createPostMedia();
+    if (mediaElement) {
+      this.appendChild(mediaElement);
+    }
+  }
+
+  createPostMedia() {
+    if (this.postData.media) {
+      const image = document.createElement("img");
+      image.src = this.postData.media;
+      image.alt = `${this.postData.author.name} posted an image with the title ${this.postData.title}.`;
+      image.classList.add("post-media");
+      return image;
+    } else {
+      return null;
+    }
+  }
+}
+
+customElements.define("post-media", PostMedia);

--- a/src/lib/page_scripts/feed.js
+++ b/src/lib/page_scripts/feed.js
@@ -1,8 +1,10 @@
 import { getAllPosts } from "../services/posts.js";
 import { Post } from "../../components/post/post.js";
+import { postStore } from "../stores/postStore.js";
 
 async function renderFeed() {
   const postsData = await getAllPosts();
+  postStore.setState(() => ({ posts: postsData }));
 
   const postsSection = document.querySelector("#posts");
   postsData.forEach((postData) => {

--- a/src/lib/stores/postStore.js
+++ b/src/lib/stores/postStore.js
@@ -1,0 +1,4 @@
+import { Store } from "./store.js";
+export const postStore = new Store({
+  posts: {},
+});

--- a/src/lib/stores/store.js
+++ b/src/lib/stores/store.js
@@ -1,0 +1,55 @@
+export class Store {
+  constructor(initialState = {}) {
+    this.state = initialState;
+    this.globalSubscribers = new Set();
+    this.keySubscribers = {};
+    this.stateHistory = [];
+  }
+
+  setState(action) {
+    const prevState = { ...this.state };
+    const newState = { ...this.state, ...action(this.state) };
+
+    this.stateHistory.push(prevState);
+    this.state = newState;
+    this.notify(prevState, newState);
+  }
+
+  notify(prevState, newState) {
+    this.globalSubscribers.forEach((sub) => sub(newState));
+
+    Object.keys(newState).forEach((key) => {
+      if (prevState[key] !== newState[key]) {
+        const subscribers = this.keySubscribers[key] || new Set();
+        subscribers.forEach((sub) => sub(newState[key]));
+      }
+    });
+  }
+
+  subscribe(callback, selector = null) {
+    if (selector === null) {
+      this.globalSubscribers.add(callback);
+      return () => this.globalSubscribers.delete(callback);
+    } else {
+      if (!this.keySubscribers[selector]) {
+        this.keySubscribers[selector] = new Set();
+      }
+
+      this.keySubscribers[selector].add(callback);
+      return () => this.keySubscribers[selector].delete(callback);
+    }
+  }
+
+  getState(selector = (s) => s) {
+    return selector(this.state);
+  }
+
+  rollback() {
+    const previousState = this.stateHistory.pop();
+    if (previousState) {
+      const currentState = { ...this.state };
+      this.state = previousState;
+      this.notify(currentState, previousState);
+    }
+  }
+}


### PR DESCRIPTION
This PR changes the Post component to use a custom store instead of the previous 
`dispatchCustomEvent` / `onCustomEvent` Hook. 

This allows for a simpler way of binding data and managing reactivity.

The Store Class can also be of use in other places of our app. 